### PR TITLE
feat: add built in chrome driver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 selenium
-
+webdriver-manager

--- a/src/Browser.py
+++ b/src/Browser.py
@@ -3,6 +3,7 @@ import re
 from log import log
 from selenium.webdriver.chrome.options import Options
 from selenium import webdriver
+from webdriver_manager.chrome import ChromeDriverManager
 import json
 
 
@@ -18,7 +19,7 @@ class Browser:
         self.options.add_argument('--disable-dev-shm-usage')
         self.options.add_argument('--disable-extensions')
         self.options.add_argument('--no-sandbox')
-        self.driver = webdriver.Chrome(options=self.options)
+        self.driver = webdriver.Chrome(ChromeDriverManager().install(), options=self.options)
         self.session_id = self.driver.session_id
         self.command_executor_url = self.driver.command_executor._url
     


### PR DESCRIPTION
Resolve casos onde o chrome driver não está presente no `PATH`, excluindo a necessidade de uma instalação manual.
Tive esse problema no sistema macOS Big Sur 11.4