### PR TITLE
fix: config location

### DIFF
--- a/src/Browser.py
+++ b/src/Browser.py
@@ -48,8 +48,6 @@ class Browser:
                 time.sleep(1)
             except:
                 pass
-            self.driver.find_element_by_id('age-gate-button-yes').click()
-            time.sleep(2)
             self.driver.find_element_by_xpath('//*[@id="fake-address-search-input"]').click()
             adress_bar = self.driver.find_element_by_xpath('//*[@id="address-search-input-address"]')
             adress_bar.clear()

--- a/src/Browser.py
+++ b/src/Browser.py
@@ -44,7 +44,7 @@ class Browser:
             self.driver.get("https://www.ze.delivery/")
             time.sleep(3)
             try:
-                self.driver.find_element_by_class_name('accept-cookie-container').click()
+                self.driver.find_element_by_id('onetrust-accept-btn-handler').click()
                 time.sleep(1)
             except:
                 pass


### PR DESCRIPTION
Removeram a classe do botão de aceitar cookies.

Atualizaram a ordem da notificação de "idade maior de 18 anos", agora ela acontece depois de pesquisar pelo endereço. Mas percebi também que esse passo agora não é mais necessário, é possível completar a navegação sem mesmo aceitar o pop-up.

c/c @Davi98 